### PR TITLE
Fix release build to produce static binary

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -17,8 +17,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential cmake
       - name: Build
         run: |
-          cmake -B build
-          cmake --build build -j --config Release
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
+          cmake --build build -j
       - name: Package
         run: |
           tar -czf whisper-cli-linux-amd64.tar.gz -C build/bin whisper-cli

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -14,6 +14,8 @@ jobs:
         run: cmake -B build -DBUILD_SHARED_LIBS=OFF
       - name: Build
         run: cmake --build build -j
+      - name: Run whisper-cli
+        run: ./build/bin/whisper-cli -h > /dev/null
       - name: Test
         run: |
           cd build

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential cmake
       - name: Configure
-        run: cmake -B build
+        run: cmake -B build -DBUILD_SHARED_LIBS=OFF
       - name: Build
         run: cmake --build build -j
       - name: Test

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ sh ./models/download-ggml-model.sh base.en
 Now build the [whisper-cli](examples/cli) example and transcribe an audio file like this:
 
 ```bash
-# build the project
-cmake -B build
-cmake --build build -j --config Release
+# build the project (static binary)
+cmake -B build -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
 
 # transcribe an audio file
 ./build/bin/whisper-cli -f samples/jfk.wav


### PR DESCRIPTION
## Summary
- build static whisper-cli in the release workflow
- ensure CI tests use static build
- document static build instructions in README

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF`
- `cmake --build build -j $(nproc)`
- `cd build && ctest -L gh --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_686d6f06fd68832aa15fe7f57fe6f830